### PR TITLE
Fix usage of tables within the document

### DIFF
--- a/template.latex
+++ b/template.latex
@@ -123,6 +123,10 @@ $if(verbatim-in-note)$
 $endif$
 $if(tables)$
 \usepackage{longtable,booktabs}
+\usepackage{supertabular}
+\let\longtable\supertabular
+\let\endlongtable\endsupertabular
+\let\endhead\relax
 % Fix footnotes in tables (requires footnote package)
 \IfFileExists{footnote.sty}{\usepackage{footnote}\makesavenoteenv{long table}}{}
 $endif$


### PR DESCRIPTION
Pandoc uses the package `longtable` to render tables. This is however
not supported in a two collum layout and results in crashes.

This patch replaces with `longtable` with `supertabular` which is
available in multi collums mode.

Signed-off-by: Paul Spooren <mail@aparcar.org>